### PR TITLE
Support different sources and .xls files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ examples/drive/drive
 
 #vendoring
 vendor
+
+# test files
+*.xls
+*.xlsx
+*.yaml

--- a/source.go
+++ b/source.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -18,12 +19,21 @@ import (
 
 const (
 	// MIME types
+	// Google sheets
 	gsheetMIME = "application/vnd.google-apps.spreadsheet"
-	xlsxMIME   = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+	// Microsoft Excel .xlsx
+	xlsxMIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+	// Microsoft Excel .xls
+	xlsMIME = "application/vnd.ms-excel"
 
 	// tempFilePrefix used for temporary file uploads
 	tempFilePrefix = "xls2sheets$"
 )
+
+var extensionMIMEmap = map[string]string{
+	".xlsx": xlsxMIME,
+	".xls":  xlsMIME,
+}
 
 // SourceFile contains the information about the source file and
 // address + range of cells to copy
@@ -66,15 +76,16 @@ func fetchFromWeb(uri string) (io.ReadCloser, error) {
 
 func fetch(loc string) (io.ReadCloser, error) {
 	switch {
-	case strings.HasPrefix(strings.ToLower(loc), "http"):
-		return fetchFromWeb(loc)
 	case strings.HasPrefix(strings.ToLower(loc), "file://"):
 		filename, err := getFilename(loc)
 		if err != nil {
 			return nil, err
 		}
 		return os.Open(filename)
+	case strings.Contains(loc, "://"):
+		return fetchFromWeb(loc)
 	default:
+		// no schema, defaults to local file
 		return os.Open(loc)
 	}
 	// UNREACHABLE
@@ -92,6 +103,7 @@ func getFilename(loc string) (string, error) {
 // FetchAndUpload downloads the file from source and uploads it to Google
 // Drive
 func (sf *SourceFile) FetchAndUpload(client *http.Client) (string, error) {
+	log.Printf("+ trying to open: %s", sf.FileLocation)
 	src, err := fetch(sf.FileLocation)
 	if err != nil {
 		return "", err
@@ -100,7 +112,7 @@ func (sf *SourceFile) FetchAndUpload(client *http.Client) (string, error) {
 	return sf.upload(client, src)
 }
 
-// Delete deletes the temporary file from the google drive
+// Delete deletes the temporary file from the google drive.
 func (sf *SourceFile) Delete(client *http.Client) error {
 	// if the file handle is nil, then upload function hasn't been called yet
 	if sf.file == nil {
@@ -120,7 +132,7 @@ func (sf *SourceFile) Delete(client *http.Client) error {
 }
 
 // upload uploads the source data to temporary google spreadsheet on
-// google drive.
+// google drive, so that it would be possible to copy data from it.
 func (sf *SourceFile) upload(client *http.Client, sourceData io.Reader) (string, error) {
 	srv, err := drive.New(client)
 	if err != nil {
@@ -129,15 +141,15 @@ func (sf *SourceFile) upload(client *http.Client, sourceData io.Reader) (string,
 	// target file name and MIME type format, so that Google Drive would
 	// convert the source excel file to Google Sheets format
 	file := drive.File{
-		Name:     generateName(tempFilePrefix),
+		Name:     generateName(tempFilePrefix, filepath.Ext(sf.FileLocation)),
 		MimeType: gsheetMIME,
 	}
 	// content type is necessary for google drive to convert the file to
 	sf.file, err = srv.Files.
 		Create(&file).
 		Media(
-			sourceData,                      // source file data
-			googleapi.ContentType(xlsxMIME), // source file MIME type
+			sourceData, // source file data
+			googleapi.ContentType(getMIME(sf.FileLocation)), // source file MIME type
 		).
 		Do()
 	if err != nil {
@@ -147,8 +159,18 @@ func (sf *SourceFile) upload(client *http.Client, sourceData io.Reader) (string,
 	return sf.file.Id, err
 }
 
-// generateName generates a (h) temporary filename
-func generateName(prefix string) string {
+// generateName generates a temporary filename.
+func generateName(prefix string, extension string) string {
 	epoch := time.Now().Unix()
-	return fmt.Sprintf("%s%d.xlsx", prefix, epoch)
+	return fmt.Sprintf("%s%d%s", prefix, epoch, extension)
+}
+
+// getMIME returns the MIME for the given filename.
+func getMIME(filename string) string {
+	mime, ok := extensionMIMEmap[strings.ToLower(filepath.Ext(filename))]
+	if !ok {
+		// BUG: defaults to xlsx mime, maybe will need to reconsider
+		return xlsxMIME
+	}
+	return mime
 }

--- a/source.go
+++ b/source.go
@@ -32,7 +32,7 @@ type SourceFile struct {
 	// Valid values:
 	//
 	// 		https://www.example.com/dataset.xlsx
-	//		file://MyWorkbook.xlsx  -- not implemented yet!
+	//		file://MyWorkbook.xlsx
 	FileLocation string `yaml:"location"`
 	// SheetAddress is the address within the source workbook.
 	// I.e. "Data!A1:U"

--- a/source_test.go
+++ b/source_test.go
@@ -8,19 +8,20 @@ import (
 
 func Test_generateName(t *testing.T) {
 	type args struct {
-		prefix string
+		prefix    string
+		extension string
 	}
 	tests := []struct {
 		name string
 		args args
 		want string
 	}{
-		{"with prefix", args{"prefix"}, "prefix" + strconv.Itoa(int(time.Now().Unix())) + ".xlsx"},
-		{"no prefix", args{""}, strconv.Itoa(int(time.Now().Unix())) + ".xlsx"},
+		{"with prefix", args{"prefix", ".xlsx"}, "prefix" + strconv.Itoa(int(time.Now().Unix())) + ".xlsx"},
+		{"no prefix", args{"", ""}, strconv.Itoa(int(time.Now().Unix())) + ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := generateName(tt.args.prefix); got != tt.want {
+			if got := generateName(tt.args.prefix, tt.args.extension); got != tt.want {
 				t.Errorf("generateName() = %v, want %v", got, tt.want)
 			}
 		})
@@ -50,6 +51,28 @@ func Test_getFilename(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("getFilename() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getMIME(t *testing.T) {
+	type args struct {
+		filename string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"excel", args{"My Documents/filename.xls"}, xlsMIME},
+		{"xlsx", args{"My Documents/filename.xlsx"}, xlsxMIME},
+		{"unknown", args{"/images/facepalm.jpg"}, xlsxMIME},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getMIME(tt.args.filename); got != tt.want {
+				t.Errorf("getMIME() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/source_test.go
+++ b/source_test.go
@@ -1,0 +1,56 @@
+package xls2sheets
+
+import (
+	"strconv"
+	"testing"
+	"time"
+)
+
+func Test_generateName(t *testing.T) {
+	type args struct {
+		prefix string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"with prefix", args{"prefix"}, "prefix" + strconv.Itoa(int(time.Now().Unix())) + ".xlsx"},
+		{"no prefix", args{""}, strconv.Itoa(int(time.Now().Unix())) + ".xlsx"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := generateName(tt.args.prefix); got != tt.want {
+				t.Errorf("generateName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getFilename(t *testing.T) {
+	type args struct {
+		loc string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{"just file", args{"file://sample.xls"}, "sample.xls", false},
+		{"full path", args{"file:///tmp/subdir/subdir2/file.txt"}, "/tmp/subdir/subdir2/file.txt", false},
+		{"current dir file", args{"file://./for_anna.xls"}, "for_anna.xls", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getFilename(tt.args.loc)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getFilename() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getFilename() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Added support for file:// and (no schema).  Defaults to local filesystem if no supported schema detected in the job for the source file
* Added support for older .xls files (basic MIME manipulation).

![](https://media1.tenor.com/images/05548ba88b6ad807885de5e519d6515c/tenor.gif?itemid=13476544)